### PR TITLE
Allow for More HTML Characters in Card Body

### DIFF
--- a/templates-blocks/cards/card.php
+++ b/templates-blocks/cards/card.php
@@ -96,7 +96,7 @@ if ( ! empty( $image_data ) ) {
 			</div>
 		<?php if ( '' !== get_field( 'body_text' ) ) : ?>
 			<div class="card-body">
-				<p class="card-text"><?php echo wp_kses( get_field( 'body_text' ), '' ); ?></p>
+				<p class="card-text"><?php echo wp_kses_post( get_field( 'body_text' ), '' ); ?></p>
 			</div>
 		<?php endif; ?>
 


### PR DESCRIPTION
Switched from `wp_kses()` to `wp_kses_post()` to allow for more HTML characters/elements to appear in our cards. This arose when we needed to use certain tags, such as `<sup>` and `<sub>`, and HTML entities like `&trade;` and `&copy;` in certain cards.

The previous code was using `wp_kses()` without any allowed tags, which was a bit too restrictive for our needs. By switching to `wp_kses_post()`, we end up allowing the tags that WordPress has deemed acceptable for standard post content - which seems like a more reasonable stance to take.
