### PR TITLE
Remove Support for Block Widget Editor

### DIFF
--- a/inc/setup.php
+++ b/inc/setup.php
@@ -24,6 +24,12 @@ if ( ! function_exists( 'uds_wp_setup' ) ) {
 	 * as indicating support for post thumbnails.
 	 */
 	function uds_wp_setup() {
+
+		/**
+		 * Remove support for the Block-based widget editor introduced in WP v5.8
+		 */
+		remove_theme_support( 'widgets-block-editor' );
+
 		/*
 		 * Make theme available for translation.
 		 * Translations can be filed in the /languages/ directory.
@@ -172,4 +178,3 @@ if ( ! function_exists( 'uds_wp_remove_thumbnail_height_width_attr' ) ) {
 		return preg_replace( '/(width|height)="\d+"\s/', '', $html );
 	}
 }
-

--- a/inc/widgets.php
+++ b/inc/widgets.php
@@ -9,12 +9,6 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Removes support for blocks in the widget areas.
- * Feature included via the Gutenberg plugin but not ready for production. (Nov 2020)
- */
-remove_theme_support( 'widgets-block-editor' );
-
-/**
  * Add filter to the parameters passed to a widget's display callback.
  * The filter is evaluated on both the front and the back end!
  *


### PR DESCRIPTION
To **temporarily** prevent the odd redirects we've been encountering when attempting to open the widget screen, this simple update removes support for the new block-based widget editor, therefore falling back to the traditional widget editor.

Changes in this PR:

- Added code to remove support for the block-based editor in `inc\setup.php`
- removed that same existing code from `inc/widgets.php`, as it didn't seem to be working when placed there

This PR is just fix the fact that you can't add widgets at all in v5.8 of WordPress, and we should fix this more completely when time allows. I'm still unsure about what, exactly, is causing the problem. Google searching points towards TinyMCE (used in the only widget we provide), but removing that particular widget (or trying a simple text input) did not solve the problem.

