### PR TITLE
Restructure Archive.php to Fix Hero Placement

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -13,18 +13,13 @@ defined( 'ABSPATH' ) || exit;
 get_header();
 
 ?>
-<?php get_template_part( 'templates-global/hero' ); ?>
-<main id="skip-to-content" <?php post_class( 'container' ); ?>>
 
-
+<main id="skip-to-content" <?php post_class(); ?>>
+	<?php get_template_part( 'templates-global/hero' ); ?>
 	<div class="container py-6">
 		<?php the_archive_title( '<h2 class="page-title mb-6">', '</h2>' ); ?>
 		<div class="row">
-
-			<?php
-
-			if ( have_posts() ) {
-
+			<?php if ( have_posts() ) {
 				// Start the loop.
 				while ( have_posts() ) {
 					the_post();
@@ -40,17 +35,14 @@ get_header();
 				get_template_part( 'templates-loop/content', 'none' );
 			}
 			?>
-
 		</div>
 	</div>
-
 	<div class="row">
 		<div class="col">
 			<!-- The pagination component -->
 			<?php uds_wp_pagination(); ?>
 		</div>
 	</div>
-
 </main><!-- #main -->
 
 <?php


### PR DESCRIPTION
While fixing some issues with our 404 and hero templates, I noticed that heroes on our category (aka 'archive') page were not staying centered on the page at very wide screen widths, but were being stuck to the left side of the screen:

<img width="1055" alt="Screen Shot 2021-08-18 at 2 39 58 PM" src="https://user-images.githubusercontent.com/31013359/129976506-1899cb13-3867-4e87-9e84-95b477195c2c.png">

After adjusting the markup (see below), I was able to get this to behave as I believe heroes are supposed to behave in 2.0 - maxing out at 1920px and staying effectively centered on screen, as shown here:

<img width="530" alt="Screen Shot 2021-08-18 at 2 51 48 PM" src="https://user-images.githubusercontent.com/31013359/129977718-c665e8c9-cbce-41fb-92a3-70ef97426ece.png">

Changes proposed in this PR include:

- move the current markup inside the existing `<main>` tag, as we do on other pages (`page.php`, `404.php`, etc.). It was outside that tag on this page.
- Remove the class "container" from that `<main>` tag. It was being applied as an argument to the `post_class()` method, but adding a container at that point added width constraints we don't want. Also, that particular argument was not included on those other pages.

