### PR TITLE
Add Full-Width Option to Buttons

### DIFF
--- a/acf-json/group_601db250e6c94.json
+++ b/acf-json/group_601db250e6c94.json
@@ -107,6 +107,25 @@
             "prepend": "",
             "append": "",
             "maxlength": ""
+        },
+        {
+            "key": "field_611d94a71a497",
+            "label": "Full Width",
+            "name": "full_width",
+            "type": "true_false",
+            "instructions": "Make button the full width of its parent container?",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "message": "",
+            "default_value": 0,
+            "ui": 1,
+            "ui_on_text": "",
+            "ui_off_text": ""
         }
     ],
     "location": [
@@ -126,5 +145,5 @@
     "hide_on_screen": "",
     "active": true,
     "description": "Fields for creating a UDS compliant button links with customizable color, size, and icon.",
-    "modified": 1616619261
+    "modified": 1629328647
 }

--- a/templates-blocks/button/button.php
+++ b/templates-blocks/button/button.php
@@ -55,6 +55,14 @@ if ( 'default' !== $button_size ) {
 	$button_size = '';
 }
 
+// Create classname for full-width buttons, if selected.
+
+if ( get_field( 'full_width' ) ) {
+	$button_full_width = 'btn-block';
+}else{
+	$button_full_width = '';
+}
+
 // If user has chosen an icon construct the markup span.
 if ( get_field( 'icon' ) ) {
 	$button_icon = sanitize_text_field( get_field( 'icon' ) );
@@ -73,5 +81,5 @@ if ( isset( $block['className'] ) && ! empty( $block['className'] ) ) {
 ?>
 
 <div class="uds-button <?php echo $additional_classes; ?>">
-	<a href="<?php echo esc_url( $button_url ); ?>" class="btn <?php echo $button_size; ?> btn-<?php echo $button_color; ?>" <?php echo $target_text; ?> <?php echo $rel; ?>> <?php echo $icon_span; ?><?php echo $button_label; ?></a>
+	<a href="<?php echo esc_url( $button_url ); ?>" class="btn <?php echo $button_size; ?> btn-<?php echo $button_color; ?> <?php echo $button_full_width; ?>" <?php echo $target_text; ?> <?php echo $rel; ?>> <?php echo $icon_span; ?><?php echo $button_label; ?></a>
 </div>


### PR DESCRIPTION
I had a request from Justin to allow for a column of equal-width buttons to match a design we were converting to the new standards. The width of a default UDS button is based entirely on the width of the button label (and icon, if present), so it's difficult to create two buttons of the same width.

I added a checkbox, which defaults to 'off', to apply Bootstrap's `btn-block` class on any UDS button, allowing for a button to take 100% of the width of its parent:

<img width="280" alt="Screen Shot 2021-08-19 at 11 07 36 AM" src="https://user-images.githubusercontent.com/31013359/130121704-c8af6caf-c025-4dc7-9180-7cc44c11cb37.png">


 This allows for buttons like the one shown in the sidebar in this image:

<img width="521" alt="Screen Shot 2021-08-19 at 11 03 02 AM" src="https://user-images.githubusercontent.com/31013359/130120940-31ea8a3d-b1f8-4784-a17b-a64199484ac6.png">

They stay full-width on mobile, resulting in this:

<img width="416" alt="Screen Shot 2021-08-19 at 11 03 23 AM" src="https://user-images.githubusercontent.com/31013359/130120965-a742de9d-30ae-4d4e-9735-b16976e3f260.png">

As I mentioned above, the Link Grid is a better, and more compliant, method. I wouldn't use full-width buttons to create giant grids of buttons (although you could do it by creating multi-column layouts of full-width buttons). However, there may be some cases where we would like two buttons of the same width for aesthetic reasons.

Changes suggested in this PR:

- Add a Yes/No field to the UDS Button field group for enabling full-width buttons. Default value is 'No'
- Apply Bootstrap's `btn-block` class to any button where the full-width value has been set to 'Yes'

Notes:

- I'm using a Bootstrap class here because I'm not sure about our theme/block support for the WordPress classes for full-width items. I'm open to other methods, but if we're based on Bootstrap we might as well take advantage of the available classes.


