### PR TITLE
New Block: UDS Banner

### DIFF
--- a/acf-json/group_611ec0462e2e5.json
+++ b/acf-json/group_611ec0462e2e5.json
@@ -1,0 +1,281 @@
+{
+    "key": "group_611ec0462e2e5",
+    "title": "UDS: Banner Block",
+    "fields": [
+        {
+            "key": "field_611ec04631bc0",
+            "label": "Color",
+            "name": "uds_banner_color",
+            "type": "select",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "choices": {
+                "green": "Green",
+                "orange": "Orange",
+                "blue": "Blue",
+                "gray": "Gray",
+                "black": "Black"
+            },
+            "default_value": "green",
+            "allow_null": 0,
+            "multiple": 0,
+            "ui": 1,
+            "ajax": 0,
+            "return_format": "value",
+            "placeholder": ""
+        },
+        {
+            "key": "field_611ec04631bc8",
+            "label": "Icon",
+            "name": "uds_banner_icon",
+            "type": "select",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "choices": {
+                "exclamation-triangle": "Triangle Alert",
+                "exclamation-circle": "Circle Alert",
+                "bell": "Bell",
+                "info-circle": "Information Circle"
+            },
+            "default_value": false,
+            "allow_null": 0,
+            "multiple": 0,
+            "ui": 0,
+            "return_format": "value",
+            "ajax": 0,
+            "placeholder": ""
+        },
+        {
+            "key": "field_611ec04631bcd",
+            "label": "Title",
+            "name": "uds_banner_title",
+            "type": "text",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "",
+            "placeholder": "Banner Title",
+            "prepend": "",
+            "append": "",
+            "maxlength": ""
+        },
+        {
+            "key": "field_611ec04631bd4",
+            "label": "Text",
+            "name": "uds_banner_text",
+            "type": "wysiwyg",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "",
+            "tabs": "all",
+            "toolbar": "basic",
+            "media_upload": 0,
+            "delay": 0
+        },
+        {
+            "key": "field_611ec04631bd9",
+            "label": "Buttons",
+            "name": "uds_banner_button_count",
+            "type": "radio",
+            "instructions": "how many buttons should appear to the right of the body text?",
+            "required": 1,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "choices": [
+                "zero",
+                "one",
+                "two"
+            ],
+            "allow_null": 0,
+            "other_choice": 0,
+            "default_value": 0,
+            "layout": "horizontal",
+            "return_format": "value",
+            "save_other_choice": 0
+        },
+        {
+            "key": "field_611ec04631bdf",
+            "label": "Button 1 Settings",
+            "name": "uds_button_1_settings",
+            "type": "group",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_611ec04631bd9",
+                        "operator": "!=",
+                        "value": "0"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "layout": "row",
+            "sub_fields": [
+                {
+                    "key": "field_611ec0463c3f8",
+                    "label": "Text",
+                    "name": "button_one_text",
+                    "type": "text",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "default_value": "",
+                    "placeholder": "Button Text",
+                    "prepend": "",
+                    "append": "",
+                    "maxlength": ""
+                },
+                {
+                    "key": "field_611ec0463c40f",
+                    "label": "URL",
+                    "name": "button_one_url",
+                    "type": "url",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "default_value": "",
+                    "placeholder": ""
+                }
+            ]
+        },
+        {
+            "key": "field_611ec04631be6",
+            "label": "Button 2 Settings",
+            "name": "uds_button_2_settings",
+            "type": "group",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_611ec04631bd9",
+                        "operator": "==",
+                        "value": "2"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "layout": "row",
+            "sub_fields": [
+                {
+                    "key": "field_611ec04642355",
+                    "label": "Text",
+                    "name": "button_two_text",
+                    "type": "text",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "default_value": "",
+                    "placeholder": "",
+                    "prepend": "",
+                    "append": "",
+                    "maxlength": ""
+                },
+                {
+                    "key": "field_611ec0464236c",
+                    "label": "URL",
+                    "name": "button_two_url",
+                    "type": "url",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "default_value": "",
+                    "placeholder": ""
+                }
+            ]
+        },
+        {
+            "key": "field_611ec0673f7b4",
+            "label": "Show Close Button?",
+            "name": "show_close_button",
+            "type": "true_false",
+            "instructions": "Show a button to hide the banner?",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "message": "",
+            "default_value": 0,
+            "ui": 1,
+            "ui_on_text": "",
+            "ui_off_text": ""
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "block",
+                "operator": "==",
+                "value": "acf\/uds-banner"
+            }
+        ]
+    ],
+    "menu_order": 0,
+    "position": "normal",
+    "style": "seamless",
+    "label_placement": "top",
+    "instruction_placement": "label",
+    "hide_on_screen": "",
+    "active": true,
+    "description": "Fields for creating a global banner across all pages, using the Banner widget area in the theme.",
+    "modified": 1629405337
+}

--- a/inc/uds-blocks.php
+++ b/inc/uds-blocks.php
@@ -56,6 +56,7 @@ function my_acf_blocks_init() {
 			'/overlay-card', // UDS Program Cards.
 			'/background-section', // UDS Background section.
 			'/modals', // UDS windows modal block.
+			'/banner', // UDS banner block.
 		);
 
 		// Loop through array items and include each register file.

--- a/templates-blocks/banner/banner.php
+++ b/templates-blocks/banner/banner.php
@@ -1,0 +1,82 @@
+<?php
+
+// I had to force lower-case on the Fontawesome icon names for them to work.
+$color = get_field( 'uds_banner_color' );
+$icon = strtolower( get_field( 'uds_banner_icon' ) );
+$title = get_field( 'uds_banner_title' );
+$body = get_field( 'uds_banner_text' );
+$button_count = get_field( 'uds_banner_button_count' );
+$show_close_button = get_field( 'show_close_button' );
+
+/**
+ * Buttons are part of an ACF form group, so we get the group first, then use
+ * standard PHP array notation to get the sub-fields of the group
+ */
+$button_one_data = get_field( 'uds_button_1_settings' );
+$button_one_text = $button_one_data['button_one_text'];
+$button_one_url = $button_one_data['button_one_url'];
+
+$button_two_data = get_field( 'uds_button_2_settings' );
+$button_two_text = $button_two_data['button_two_text'];
+$button_two_url = $button_two_data['button_two_url'];
+
+/**
+ * There are conditions for rendering buttons: the number
+ * of buttons, and which button color to use based on the background,
+ * so there's a bit more work than just grabbing the values from ACF
+ */
+
+// we'll build a 'button block' based on those conditions.
+$button_block = '';
+$button_block_open = '<div class="banner-buttons">';
+$button_block_close = '</div>';
+
+// if our button count is more than zero, we have buttons to build.
+if ( $button_count ) {
+
+	// add the opening markup to our button block.
+	$button_block .= $button_block_open;
+
+	// set a button class to make sure we don't make black buttons on a black BG.
+	// all banner colors, besides black, use the dark buttons.
+	$button_class = 'dark';
+	if ( 'black' == $color ) {
+		$button_class = 'gold';
+	}
+
+	// if we got here we have more than zero buttons, so we will render button #1.
+	$button_block .= '<a href="' . $button_one_url . '" class="btn btn-sm btn-' . $button_class . '">' . $button_one_text . '</a>';
+
+	// if we have two buttons (the maximum), we also render button #2.
+	if ( 2 == $button_count ) {
+		$button_block .= '<a href="' . $button_two_url . '" class="btn btn-sm btn-' . $button_class . '">' . $button_two_text . '</a>';
+	}
+
+	// add the closing markup to the button block.
+	$button_block .= $button_block_close;
+}
+?>
+
+<div class="container-fluid banner-<?php echo $color; ?>">
+	<div class="container">
+		<div class="row">
+			<div class="col">
+				<div class="banner" role="banner">
+					<div class="banner-icon">
+						<span title="Banner" class="fa fa-icon fa-<?php echo $icon; ?>"></span>
+					</div>
+					<div class="banner-content">
+						<h3><?php echo $title; ?></h3>
+						<?php echo $body; ?>
+					</div>
+					<?php echo $button_block; ?>
+					<?php if( $show_close_button ): ?>
+						<div class="banner-close">
+							<button type="button" class="btn btn-circle btn-circle-alt-white close" aria-label="Close" onclick="event.target.parentNode.parentNode.style.display='none';">x</button>
+						</div>
+					<?php endif; ?>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>

--- a/templates-blocks/banner/banner.php
+++ b/templates-blocks/banner/banner.php
@@ -20,6 +20,12 @@ $button_two_data = get_field( 'uds_button_2_settings' );
 $button_two_text = $button_two_data['button_two_text'];
 $button_two_url = $button_two_data['button_two_url'];
 
+// If additional classes were requested, clean up the input and add them.
+$additional_classes = '';
+if ( isset( $block['className'] ) && ! empty( $block['className'] ) ) {
+	$additional_classes = trim( sanitize_text_field( $block['className'] ) );
+}
+
 /**
  * There are conditions for rendering buttons: the number
  * of buttons, and which button color to use based on the background,
@@ -57,8 +63,7 @@ if ( $button_count ) {
 }
 ?>
 
-<div class="container-fluid banner-<?php echo $color; ?>">
-	<div class="container">
+	<div class="container banner-<?php echo $color; ?> <?php echo $additional_classes; ?>">
 		<div class="row">
 			<div class="col">
 				<div class="banner" role="banner">
@@ -79,4 +84,3 @@ if ( $button_count ) {
 			</div>
 		</div>
 	</div>
-</div>

--- a/templates-blocks/banner/banner.php
+++ b/templates-blocks/banner/banner.php
@@ -63,7 +63,8 @@ if ( $button_count ) {
 }
 ?>
 
-	<div class="container banner-<?php echo $color; ?> <?php echo $additional_classes; ?>">
+<div class="container-fluid banner-<?php echo $color; ?> <?php echo $additional_classes; ?>">
+	<div class="container">
 		<div class="row">
 			<div class="col">
 				<div class="banner" role="banner">
@@ -84,3 +85,4 @@ if ( $button_count ) {
 			</div>
 		</div>
 	</div>
+</div>

--- a/templates-blocks/banner/register.php
+++ b/templates-blocks/banner/register.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Block Registration
+ *
+ * Block name: Banner
+ * Author: Walter McConnell
+ * Version: 1.0
+ *
+ * @package UDS WordPress Theme
+ *
+ * A block for creating a dynamic UDS banner (such as a COVID banner)
+ */
+
+acf_register_block_type(
+	array(
+		'name'              => 'uds-banner', // internal name, like a slug.
+		'title'             => __( 'UDS Banner', 'uds-wordpress-theme' ), // name the user will see.
+		'description'       => __( 'A UDS compliant banner, with customizable text and styles.', 'uds-wordpress-theme' ), // description the user will see.
+		'icon'              => 'info-outline', // Dashicon, or custom SVG code, for the icon.
+		'render_template'   => 'templates-blocks/banner/banner.php', // location of the block's template.
+		'category'          => 'uds', // category this block appears in.
+		'keywords'          => array( 'banner', 'message', 'text' ),
+		'supports'          => array(
+			'align' => false, // Remove the align button in the editor toolbar.
+		),
+		'mode'              => 'preview', // make this block default to full edit mode when added to the page.
+		'example'  => array(
+			'attributes' => array(
+				'mode' => 'preview',
+				'data' => array(
+					'alert_style'   => 'info',
+					'alert_content' => 'Your alert text here.',
+				),
+			),
+		),
+	)
+);


### PR DESCRIPTION
While we have a widget, and a widget area, for banners across multiple pages - we don't have a way to easily insert a single UDS banner on a page. With the COVID banner seeming demoted to more of an 'alert' status, but still retaining banner styles, I figured we should also have a block for adding banners.

Already wrapped in a fluid container, the block can be used directly at the root level of a page for a max-width banner, like this:

<img width="399" alt="Screen Shot 2021-08-19 at 4 30 39 PM" src="https://user-images.githubusercontent.com/31013359/130157797-418453a0-84d9-4dac-bb11-4a85b844815e.png">

Or within a container/row/column structure to fit within the content area, like this:

<img width="399" alt="Screen Shot 2021-08-19 at 4 33 01 PM" src="https://user-images.githubusercontent.com/31013359/130157823-e546a798-f774-4a44-a3ec-d9a5d83ad584.png">

Changes proposed in this PR:

- Add a new block version of the existing banner widget, with the following features:
  - All features of the widget (multiple banner colors, icons, up to two buttons)
  - Ability to hid the 'Close' button to make banners that cannot be dismissed (i.e. the COVID banner)
