### PR TITLE
Remove Unwanted Pagragraph Tags in Cards

### DIFF
--- a/templates-blocks/cards/card.php
+++ b/templates-blocks/cards/card.php
@@ -92,11 +92,11 @@ if ( ! empty( $image_data ) ) {
 			<div class="card-content-wrapper" />
 		<?php endif; ?>
 			<div class="card-header">
-				<h3 class="card-title"><?php echo wp_kses_post( get_field( 'title' ), '' ); ?></h3>
+				<h3 class="card-title"><?php the_field( 'title', false, false ); ?></h3>
 			</div>
 		<?php if ( '' !== get_field( 'body_text' ) ) : ?>
 			<div class="card-body">
-				<p class="card-text"><?php echo wp_kses_post( get_field( 'body_text' ), '' ); ?></p>
+				<p class="card-text"><?php the_field( 'body_text', false, false ); ?></p>
 			</div>
 		<?php endif; ?>
 


### PR DESCRIPTION
When we switched to using the ACF Pro WYSIWYG editor for card titles, and allowed for additional special characters in the body text, we introduced additional paragraph tags in both the title and body where we didn't want them.

A basic card title should be created like this: `<h2>Title text here</h2>`

But the WYSIWYG editor was adding paragraphs around the content like this: `<h2><p>Title text here</p></h2>`

We were also seeing extra `<p>` tags in the body content, sometimes more than one, causing some non-standard spacing between title and body text.

Changes proposed in this PR:

- Use the additional formatting argument when retrieving the ACF values for title and body text. By passing `false` as the argument, ACF will not include the extra formatting (the `<p>` tags) when retrieving the values.
- Since ACF Pro now automatically uses `wp_kses()` on all content, switch from using `get_field()` to `the_field()` to retrieve and display the value all at once.