### PR TITLE
Tabbed Panels Block

### DIFF
--- a/acf-json/group_615496a6a9c27.json
+++ b/acf-json/group_615496a6a9c27.json
@@ -1,0 +1,62 @@
+{
+    "key": "group_615496a6a9c27",
+    "title": "UDS Tabbed Panels",
+    "fields": [
+        {
+            "key": "field_615496a6ae434",
+            "label": "Tab title",
+            "name": "uds_single_tab_title",
+            "type": "text",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "",
+            "placeholder": "",
+            "prepend": "",
+            "append": "",
+            "maxlength": ""
+        },
+        {
+            "key": "field_615496a6ae4b2",
+            "label": "Icon",
+            "name": "uds_single_tab_title_icon",
+            "type": "text",
+            "instructions": "Enter all required FA classes. Example: <code>fas fa-external-link-alt<\/code>.",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "",
+            "placeholder": "",
+            "prepend": "",
+            "append": "",
+            "maxlength": ""
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "block",
+                "operator": "==",
+                "value": "acf\/uds-tabbed-panels"
+            }
+        ]
+    ],
+    "menu_order": 0,
+    "position": "normal",
+    "style": "default",
+    "label_placement": "top",
+    "instruction_placement": "label",
+    "hide_on_screen": "",
+    "active": true,
+    "description": "",
+    "modified": 1632951686
+}

--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -37,6 +37,9 @@ if ( ! function_exists( 'uds_wp_scripts' ) ) {
 		$js_modals_version = $theme_version . '.' . filemtime( get_template_directory() . '/js/modals.js' );
 		wp_enqueue_script( 'uds-wordpress-modals-scripts', get_template_directory_uri() . '/js/modals.js', array(), $js_modals_version, true );
 
+		$js_tabbed_panels_version = $theme_version . '.' . filemtime( get_template_directory() . '/js/tabbed-panels.js' );
+		wp_enqueue_script( 'uds-wordpress-tabbed_panels-scripts', get_template_directory_uri() . '/js/tabbed-panels.js', array(), $js_tabbed_panels_version, true );
+
 
 		if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
 			wp_enqueue_script( 'comment-reply' );
@@ -76,6 +79,7 @@ if ( ! function_exists( 'uds_wp_admin_scripts' ) ) {
 
 		$js_version = $theme_version . '.' . filemtime( get_template_directory() . '/js/theme.min.js' );
 		wp_enqueue_script( 'uds-wordpress-scripts', get_template_directory_uri() . '/js/theme.min.js', array(), $js_version, true );
+
 	}
 } // End of if function_exists( 'uds_wp_scripts' ).
 add_action( 'admin_enqueue_scripts', 'uds_wp_admin_scripts' );

--- a/inc/uds-blocks.php
+++ b/inc/uds-blocks.php
@@ -59,6 +59,7 @@ function my_acf_blocks_init() {
 			'/banner', // UDS banner block.
 			'/grid-links',              // UDS Grid Links.
 			'/foldable-card', // UDS Foldable card block.
+			'/tabbed-panels', // UDS Tabbed panels block.
 		);
 
 		// Loop through array items and include each register file.

--- a/js/tabbed-panels.js
+++ b/js/tabbed-panels.js
@@ -1,0 +1,113 @@
+/**
+ * File tabbed-panels.js.
+ *
+ * JS for tabbed panels block.
+ *
+ */
+
+/*jshint esversion: 6 */
+'use strict';
+const setButtonsCompatibility = (e) => {
+		const targets = ['a', 'button'];
+		if (targets.includes(e.target.localName)) {
+			e.target.focus();
+		}
+	};
+
+	const setControlVisibility = (clicked, scrollOffset) => {
+		const parentContainer = $(clicked).closest('.uds-tabbed-panels');
+		const parentNav = $(clicked).siblings('.nav-tabs');
+		const scrollPosition = parentNav.data('scroll-position') * 1;
+		const tabPosition = parentNav[0].scrollWidth - scrollOffset;
+
+		if (scrollPosition == 0) {
+			parentContainer.find('.scroll-control-prev').hide();
+		} else {
+			parentContainer.find('.scroll-control-prev').show();
+		}
+		if (tabPosition <= parentContainer.width()) {
+			parentContainer.find('.scroll-control-next').hide();
+		} else {
+			parentContainer.find('.scroll-control-next').show();
+		}
+	};
+
+	const slideNav = (clicked, e, direction) => {
+		e.preventDefault();
+		const parentNav = $(clicked).siblings('.nav-tabs');
+		let scrollPosition = parentNav.data('scroll-position') * 1;
+		const navItems = parentNav.find('.nav-item').toArray();
+		let scrollOffset = parentNav.css('left').replace('px', '') * 1;
+		var adjustNavItem = 0;
+
+		if (direction == 1 && scrollPosition > 0) {
+			scrollPosition -= 1;
+		}
+		if (scrollPosition < navItems.length - 1 && direction == -1) {
+			scrollPosition += 1;
+		}
+		parentNav.data('scroll-position', scrollPosition);
+
+		scrollOffset = 0;
+		for (var i = 0; i < scrollPosition; i++) {
+			scrollOffset += $(navItems[i]).outerWidth();
+		}
+
+		parentNav.scrollLeft(scrollOffset);
+
+		setControlVisibility(clicked, scrollOffset);
+	};
+
+( function( $ ) {
+
+$('.uds-tabbed-panels').closest('.wp-block-group').addClass('uds-tabs-wrapper');
+
+$('.wp-block-group.uds-tabs-wrapper').each(function(){
+	var tab_nav_items = [];
+		 $(this).find('.uds-tabbed-panels').each(function(){
+			 var tab_nav_item = $(this).find('.nav.nav-tabs').html();
+			 $(this).find('.nav.nav-tabs').empty();
+			 tab_nav_items.push(tab_nav_item);
+		 });
+		 $(this).find('nav.uds-tabbed-panels:not(:first-of-type)').remove();
+		 $(this).find('nav.uds-tabbed-panels .nav.nav-tabs').append(tab_nav_items);
+		 $(this).find('nav.uds-tabbed-panels .nav.nav-tabs .nav-item:not(:first-of-type)').removeClass('active');
+		 $(this).find('nav.uds-tabbed-panels .nav.nav-tabs .nav-item:not(:first-of-type)').attr('aria-selected', 'false');
+	tab_nav_items = [];
+
+	var tab_content_items = [];
+			$(this).find('.tab-content').each(function(){
+				var tab_content_item = $(this).html();
+				$(this).empty();
+				tab_content_items.push(tab_content_item);
+			});
+			$(this).find('.tab-content:not(:first-of-type)').remove();
+			$(this).find('.tab-content').append(tab_content_items);
+			$(this).find('.tab-content .tab-pane:not(:first-of-type)').removeClass('show active');
+	tab_content_items = [];
+});
+
+
+$(document).on('click', function (e) {
+      setButtonsCompatibility(e);
+    });
+
+    $('.scroll-control-next').on('click', function (e) {
+      if (window.innerWidth > 992) {
+        slideNav(this, e, -1);
+      }
+    });
+
+    $('.scroll-control-prev').on('click', function (e) {
+      if (window.innerWidth > 992) {
+        slideNav(this, e, 1);
+      }
+    });
+
+    $('.uds-tabbed-panels .scroll-control-prev').hide();
+
+    if ($('.nav.nav-tabs')[0].scrollWidth <= $('.uds-tabbed-panels').width()) {
+      $('.uds-tabbed-panels .scroll-control-next').hide();
+    }
+
+} )( jQuery );

--- a/templates-blocks/tabbed-panels/register.php
+++ b/templates-blocks/tabbed-panels/register.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Block Registration
+ *
+ * Block name: UDS Tabbed panels block
+ * Author: Zainab Alsidiki
+ * Version: 0.1
+ *
+ * @package UDS WordPress Theme
+ *
+ * Notes: A block for the Tabbed panels.
+ */
+
+acf_register_block_type(
+	array(
+		'name'              => 'uds-tabbed-panels',
+		'title'             => __( 'UDS Tabbed panels', 'uds-wordpress-theme' ),
+		'description'       => __( 'A Tabbed panels block', 'uds-wordpress-theme' ),
+		'icon'              => 'table-row-after',
+		'render_template'   => 'templates-blocks/tabbed-panels/tabbed-panels.php',
+		'category'          => 'layout',
+		'keywords'          => array( 'tabs', 'tab', 'tabbed', 'panel', 'panels', 'nav'),
+		'supports'          => array(
+			'align' => false,
+			'jsx' => true,
+		),
+		'mode'              => 'edit',
+	)
+);

--- a/templates-blocks/tabbed-panels/tabbed-panels.php
+++ b/templates-blocks/tabbed-panels/tabbed-panels.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * UDS Foldable card block
+ *
+ * @package UDS WordPress Theme
+ */
+
+ $tab_id = 'tab_' . $block['id'];
+ $tab_title = get_field( 'uds_single_tab_title' );
+ $tab_icon = get_field( 'uds_single_tab_title_icon' );
+
+
+
+ if($tab_icon){
+	 $tab_icon='<i class="'. $tab_icon .'"></i>';
+ }
+
+$additional_classes = '';
+if ( ! empty( $block['className'] ) ) {
+	$additional_classes = $block['className'];
+}
+
+
+
+	// Sets InnerBlocks with a Bootstrap blocks container as default content.
+	$allowed_blocks = array( 'wp-bootstrap-blocks/container', 'core/html' );
+	$template = array(
+		array(
+			'wp-bootstrap-blocks/container',
+			array(
+				'marginAfter' => 'mb-0',
+			),
+		),
+	);
+
+echo '
+<nav class="uds-tabbed-panels">
+            <div class="nav nav-tabs" data-scroll-position="0" id="nav_'.$tab_id.'" role="tablist" >
+              <a
+                aria-controls="'. $tab_id .'"
+                aria-selected="true"
+                class="nav-item nav-link active"
+                data-toggle="tab"
+                href="#'. $tab_id .'"
+                id="'. $tab_id .'-nav"
+                role="tab"
+              >
+              '. $tab_icon . $tab_title .'
+              </a>
+							</div>
+							<a
+              class="scroll-control-prev"
+              data-scroll="prev"
+              href="#carouselExampleControls"
+              role="button"
+              tabIndex="-1"
+            >
+              <span
+                aria-hidden="true"
+                class="carousel-control-prev-icon"
+              />
+              <span class="sr-only">
+                Previous
+              </span>
+            </a>
+            <a
+              class="scroll-control-next"
+              data-scroll="next"
+              href="#carouselExampleControls"
+              role="button"
+              tabIndex="-1"
+            >
+              <span
+                aria-hidden="true"
+                class="carousel-control-next-icon"
+              />
+              <span class="sr-only">
+                Next
+              </span>
+            </a>
+							</nav>
+<div class="tab-content" id="nav_'.$tab_id.'Content">
+  <div
+	aria-labelledby="'. $tab_id .'-nav"
+	class="tab-pane fade show active '. $additional_classes .'"
+	id="'. $tab_id .'"
+	role="tabpanel"
+>
+';
+	echo '<InnerBlocks allowedBlocks="' . esc_attr( wp_json_encode( $allowed_blocks ) ) . '" template="' . esc_attr( wp_json_encode( $template ) ) . '" />';
+
+echo '</div>
+</div>';
+
+?>


### PR DESCRIPTION
In this PR I created a new ACF block for Tabbed Panels. 
![Screen Shot 2021-09-29 at 3 36 39 PM](https://user-images.githubusercontent.com/15880606/135357970-8386b16f-9d01-47af-b662-c948ad8847c7.png)

It allows to add a single tab at a time: 
![Screen Shot 2021-09-29 at 3 29 05 PM](https://user-images.githubusercontent.com/15880606/135357443-ef332cfc-320f-44a8-bdc7-20c141f4bed3.png)

And has two fields, one for **title**, and one for **icon** to be shown next to the title: 
![Screen Shot 2021-09-29 at 3 32 50 PM](https://user-images.githubusercontent.com/15880606/135357681-ae487927-0472-46d5-a740-7c37a37cfa7a.png)
![Screen Shot 2021-09-29 at 3 31 27 PM](https://user-images.githubusercontent.com/15880606/135357569-b99df271-eeef-416c-9e99-28b48fca50d3.png)

If you switch to **preview** mode, you can add any Gutenberg blocks to the tab content:
![Screen Shot 2021-09-29 at 3 33 52 PM](https://user-images.githubusercontent.com/15880606/135357761-0782473f-893d-4393-90cc-6c3b9a46c187.png)

![Screen Shot 2021-09-29 at 3 34 39 PM](https://user-images.githubusercontent.com/15880606/135357830-a4a2c09f-6e4a-4f0a-8a3c-4b5326c418e3.png)

Then, to add multiple tabs together to show as one tabbed panel, you can select all single tabs, then group them into a group block (from the 3 dots at the right top corner, select "**group**" option):
![Screen Shot 2021-09-29 at 3 41 31 PM](https://user-images.githubusercontent.com/15880606/135358489-9e702c74-1467-40d2-9e49-48a3d005013e.png)




