### PR TITLE
Bring Back the Dart SASS Compiler

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,7 +20,7 @@ var cfg = require("./gulpconfig.json");
 var paths = cfg.paths;
 
 // Use Dart Sass to avoid random compliation errors.
-//sass.compiler = require("sass");
+sass.compiler = require("sass");
 
 /**
  * Compiles .scss to .css files.


### PR DESCRIPTION
After merging our recent updates to `Gulpfile.js`, I noticed that I had neglected to uncomment this one line that will re-activate the Dart SASS compiler. As a result, I appeared to be using a global installation of `lib-sass` I had on my system for another project.

I uncommented the line and tried a rebuild of the theme. Aside from Dart complaining about using the `/` symbol for division (something used in the upstream SASS files), everything worked and the theme files compiled as expected.

Changes in this pull request:

- Uncomment the line that sets Dart as the SASS compiler

