### PR TITLE
Tabbed panel js

### DIFF
--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -37,8 +37,6 @@ if ( ! function_exists( 'uds_wp_scripts' ) ) {
 		$js_modals_version = $theme_version . '.' . filemtime( get_template_directory() . '/js/modals.js' );
 		wp_enqueue_script( 'uds-wordpress-modals-scripts', get_template_directory_uri() . '/js/modals.js', array(), $js_modals_version, true );
 
-		$js_tabbed_panels_version = $theme_version . '.' . filemtime( get_template_directory() . '/js/tabbed-panels.js' );
-		wp_enqueue_script( 'uds-wordpress-tabbed_panels-scripts', get_template_directory_uri() . '/js/tabbed-panels.js', array(), $js_tabbed_panels_version, true );
 
 
 		if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {

--- a/templates-blocks/tabbed-panels/register.php
+++ b/templates-blocks/tabbed-panels/register.php
@@ -18,6 +18,7 @@ acf_register_block_type(
 		'description'       => __( 'A Tabbed panels block', 'uds-wordpress-theme' ),
 		'icon'              => 'table-row-after',
 		'render_template'   => 'templates-blocks/tabbed-panels/tabbed-panels.php',
+		'enqueue_script'    => get_template_directory_uri() . '/js/tabbed-panels.js',
 		'category'          => 'layout',
 		'keywords'          => array( 'tabs', 'tab', 'tabbed', 'panel', 'panels', 'nav'),
 		'supports'          => array(


### PR DESCRIPTION
I removed the tabbed panel js file from the theme enqueue file to enqueue it into the block register file, to avoid getting a js error in all pages that don't have a tabbed panel.

```
Uncaught TypeError: Cannot read properties of undefined (reading 'scrollWidth')
    at tabbed-panels.js?ver=0.28.1637107573:110
    at tabbed-panels.js?ver=0.28.1637107573:114
```

