### PR TITLE
CTA buttons in mega menu

### DIFF
--- a/asu-navigation-menu.php
+++ b/asu-navigation-menu.php
@@ -112,7 +112,7 @@ foreach ( $menu_items as $item ) :
 								foreach ( $item['children'] as $child ) :
 									// if $child is flagged as a CTA button, it is a mega-menu CTA button, outside of columns.
 									if ( $child['cta_button'] ) {
-										$mega_cta_buttons .= uds_wp_render_nav_cta_button( $child['cta_color'], $item );
+										$mega_cta_buttons .= uds_wp_render_nav_cta_button( $child['cta_color'], $child );
 										continue;
 									}
 


### PR DESCRIPTION
I updated the CTA buttons in mega menu to show the correct title when a sub-item is turned on as a CTA button in mega menu: 
![Screen Shot 2021-12-02 at 4 25 43 PM](https://user-images.githubusercontent.com/15880606/144519196-241f6a1f-4664-444e-9040-b0a00d594aa3.png)

