### PR TITLE
Prevent Google from crawling our Sign In and Sign Out Links

### DIFF
--- a/header.php
+++ b/header.php
@@ -141,9 +141,9 @@ if (!empty($c_options['hotjar_site_id'])) {
 							<div class="nav-link login-status">
 								<?php
 								if (is_user_logged_in()) {
-									echo $current_user->display_name . '<a class="signout" href="' . wp_logout_url(home_url()) . '">Sign Out</a>';
+									echo $current_user->display_name . '<a class="signout" rel="nofollow" href="' . wp_logout_url(home_url()) . '">Sign Out</a>';
 								} else {
-									echo '<a class="signin" href="' . get_home_url() . '/wp-admin">Sign In</a>';
+									echo '<a class="signin" rel="nofollow" href="' . get_home_url() . '/wp-admin">Sign In</a>';
 								}
 								?>
 

--- a/header.php
+++ b/header.php
@@ -221,9 +221,9 @@ if (!empty($c_options['hotjar_site_id'])) {
 								<div class="nav-link login-status">
 									<?php
 									if (is_user_logged_in()) {
-										echo $current_user->display_name . '<a class="signout" href="' . wp_logout_url(home_url()) . '">Sign Out</a>';
+										echo $current_user->display_name . '<a class="signout" rel="nofollow" href="' . wp_logout_url(home_url()) . '">Sign Out</a>';
 									} else {
-										echo '<a class="signin" href="' . get_home_url() . '/wp-admin">Sign In</a>';
+										echo '<a class="signin" rel="nofollow" href="' . get_home_url() . '/wp-admin">Sign In</a>';
 									}
 									?>
 


### PR DESCRIPTION
We recently updated our theme to have the global 'Sign In' and 'Sign Out' links point to the local WordPress admin (/wp-admin) instead of my.asu.edu, but didn't realize that we need to prevent Google from trying to follow those links and sign in to our sites.

Not only is this a possible security issue, but signing in fires off a string of redirects - first within WordPress, then to ASU's SSO, then back - that cause errors in Google Search Console.

Changes suggested in this PR:

- Add "rel=nofollow" to both links to prevent Google from following them