### PR TITLE
Fix JS Console Notice and Restore Block Inserter Functionality

### DIFF
--- a/js/tabbed-panels.js
+++ b/js/tabbed-panels.js
@@ -89,7 +89,7 @@ $( '.wp-block-group.uds-tabs-wrapper' ).each(function() {
 });
 
 
-$( document ).on( 'click', function( e ) {
+$( '.uds-tabbed-panels' ).on( 'click', function( e ) {
       setButtonsCompatibility( e );
     });
 

--- a/js/tabbed-panels.js
+++ b/js/tabbed-panels.js
@@ -107,8 +107,10 @@ $( document ).on( 'click', function( e ) {
 
     $( '.uds-tabbed-panels .scroll-control-prev' ).hide();
 
-    if ( $( '.nav.nav-tabs' )[0].scrollWidth <= $( '.uds-tabbed-panels' ).width() ) {
-      $( '.uds-tabbed-panels .scroll-control-next' ).hide();
-    }
+	if ( $('.nav.nav-tabs').length > 0 ) {
+		if ( $( '.nav.nav-tabs' )[0].scrollWidth <= $( '.uds-tabbed-panels' ).width() ) {
+		$( '.uds-tabbed-panels .scroll-control-next' ).hide();
+		}
+	}
 
 } )( jQuery );


### PR DESCRIPTION
## The Issues

While working on some preliminary pattern library stuff, I noticed two things:

1. I was consistently seeing ` undefined is not an object (evaluating '$( '.nav.nav-tabs' )[0].scrollWidth')` in the Javascript console. This was always showing up in the editor, and on the front-end in certain situations. It was caused by the difference in the structure of tabs on the front end and in the editor.
2. We could not longer click the 'Browse All' button in the modal block inserter  (shown in image below) to open the full block inserter. Clicking that button would do nothing. This was caused by a function we had in place to prevent the unwanted following of certain clicks in the editor. That method was swallowing up the click on the 'Browse All' button.


<img width="321" alt="Screen Shot 2022-11-01 at 3 57 33 PM" src="https://user-images.githubusercontent.com/31013359/199358432-27af1987-07f4-4b55-8329-33a15aebdda4.png">


## The Solutions

1. Wrap the attempt to access the first child of the array of tabs in a check to make sure that the `.length` of that array is greater than zero. Because it's not actually an array in the editor, this short-circuits the whole thing and doesn't try to access that child
2. Limit the scope of the clicks we are capturing to only those that occur within a `.nav-tabs` element. There may be a better solution to this one in the long run, but I was focused on restoring that default functionality first.
