### PR TITLE
Add Customizer field for Google Search Console ownership verification

### DIFF
--- a/header.php
+++ b/header.php
@@ -13,6 +13,7 @@ defined('ABSPATH') || exit;
 
 $c_options              = array();
 $asu_hub_analytics     = 'disabled';
+$site_gcs_ownership_verification_id = '';
 $site_gtm_container_id = '';
 $site_ga_tracking_id   = '';
 $hotjar_site_id        = '';
@@ -29,6 +30,10 @@ if (!empty($c_options['header_navigation_menu'])) {
 // Do we have an asu_hub_analytics setting?
 if (!empty($c_options['asu_hub_analytics'])) {
 	$asu_hub_analytics = $c_options['asu_hub_analytics'];
+}
+// Do we have a site_gcs_ownership_verification_id setting?
+if (!empty($c_options['site_gcs_ownership_verification_id'])) {
+	$site_gcs_ownership_verification_id = $c_options['site_gcs_ownership_verification_id'];
 }
 // Do we have a site_gtm_container_id setting?
 if (!empty($c_options['site_gtm_container_id'])) {
@@ -95,6 +100,12 @@ if (!empty($c_options['hotjar_site_id'])) {
 	add_action('include_lavidge_script', 'uds_wp_include_lavidge_script', 10, 2);
 	do_action('include_lavidge_script');
 
+
+	// Google Search Console Ownership Verification.
+	// Only add the Ownership Verification meta tag on the site homepage
+	if (!empty($site_gcs_ownership_verification_id) && is_front_page() ) {
+		echo '<meta name="google-site-verification" content="' . esc_html( trim( $site_gcs_ownership_verification_id ) )  . '" />';
+	}
 
 	// Site Google Tag Manager.
 	if (!empty($site_gtm_container_id)) {

--- a/inc/customizer/customizer-settings.php
+++ b/inc/customizer/customizer-settings.php
@@ -1153,7 +1153,7 @@ if ( ! function_exists( 'uds_wp_register_theme_customizer_settings' ) ) {
 			array(
 				'label'             => __( 'Google Search Console Ownership Verification ID', 'uds-wordpress-theme' ),
 				'description'       => __(
-					'Ownership verification means proving to Search Console that you own a specific website. Choose the HTML tag method on the Ownership verification page for your property. In the HTML snippet provided, copy the "content" value: <meta name="google-site-verification" content="COPY_AND_PASTE_THIS_VALUE" />.',
+					'In Search Console, choose the HTML tag method on the Ownership verification page. In the provided HTML snippet, copy the content value: content="COPY_AND_PASTE_THIS_VALUE".',
 					'uds-wordpress-theme'
 				),
 				'section'           => 'uds_wp_theme_section_asu_analytics',

--- a/inc/customizer/customizer-settings.php
+++ b/inc/customizer/customizer-settings.php
@@ -1136,6 +1136,34 @@ if ( ! function_exists( 'uds_wp_register_theme_customizer_settings' ) ) {
 		);
 
 		/**
+		 * Site Google Search Console (GCS) ownership verification id
+		 */
+		$wp_customize->add_setting(
+			'site_gcs_ownership_verification_id',
+			array(
+				'capability'        => 'edit_theme_options',
+				'type'              => 'theme_mod',
+				'sanitize_callback' => 'uds_wp_sanitize_nothing',
+				'transport'         => 'refresh',
+			)
+		);
+
+		$wp_customize->add_control(
+			'site_gcs_ownership_verification_id',
+			array(
+				'label'             => __( 'Google Search Console Ownership Verification ID', 'uds-wordpress-theme' ),
+				'description'       => __(
+					'Ownership verification means proving to Search Console that you own a specific website. Choose the HTML tag method on the Ownership verification page for your property. In the HTML snippet provided, copy the "content" value: <meta name="google-site-verification" content="COPY_AND_PASTE_THIS_VALUE" />.',
+					'uds-wordpress-theme'
+				),
+				'section'           => 'uds_wp_theme_section_asu_analytics',
+				'settings'          => 'site_gcs_ownership_verification_id',
+				'type'              => 'input',
+				'sanitize_callback' => 'uds_wp_sanitize_nothing',
+			)
+		);
+
+		/**
 		 * Site Google Tag Manager
 		 */
 		$wp_customize->add_setting(


### PR DESCRIPTION
In order to add a website to Google Search Console, we must prove we own the site: https://support.google.com/webmasters/answer/9008080?hl=en#meta_tag_verification

This PR adds a new Customizer field in the ASU Analytics section to set the ownership verification id.

1. Choose the HTML tag method on the [Ownership verification page](https://search.google.com/search-console/ownership) for your property.
2. Copy the "content" value from the provided HTML snippet in the Search Console verification wizard:
```
<meta name="google-site-verification" content="COPY_PASTE_THIS_VALUE" />
```
3. Paste into Customizer field:
<img width="300" alt="Screen Shot 2022-11-02 at 3 55 20 PM" src="https://user-images.githubusercontent.com/1801352/199618931-e7822f96-bd01-4861-8fe0-a337301edfba.png">

