### PR TITLE
bug fix: empty container for sidebar menu

### DIFF
--- a/inc/shortcodes.php
+++ b/inc/shortcodes.php
@@ -38,17 +38,16 @@ function uds_wordpress_shortcode_sidebar_menu( $atts ) {
 	} else {
 		$sidebar_title = '';
 	}
-
 	// Build the menu with our nav walker.
 	$sidebar = wp_nav_menu(
 		array(
 			'menu'            => $menu,
 			'echo'            => false,
 			'walker'          => new Uds_Custom_Walker_Widget_Nav_Menu(),
-			'items-wrap'      => '%3$s',
+			'container'      => '',
+			'items_wrap'    => '%3$s',
 		)
 	);
-
 	// Return the menu inside the wrapper.
 	return $wrapper . $sidebar . '</nav>';
 }


### PR DESCRIPTION
For some reason in the old setup, the sidebar shortcode is getting passed from `shortcodes.php` to `navigation-widget.php`, and `navigation-widget.php` is custom building an array with a pseudo wp_nav_menu-style function with an empty container, while `shortcodes.php` is using the built-in `wp_nav_menu()` which has a default `<ul>` container.

Since we have to change the logic in  `navigation-widget.php` for the react header to work, I just added an empty container to the shortcode walker.