### PR TITLE
redirect to previous page after CAS login

### DIFF
--- a/inc/header-localizer-script.php
+++ b/inc/header-localizer-script.php
@@ -144,7 +144,7 @@ if (!function_exists('uds_localize_component_header_script')) {
 		// Prep localized array items for wp_localize_script below.
 		$localized_array = 	array(
 			'loggedIn' => is_user_logged_in(),
-			'loginLink' => site_url() . '/wp-admin',
+			'loginLink' => site_url() . '/wp-admin' . '?redirect_to=' . urlencode($_SERVER['REQUEST_URI']),
 			'logoutLink' => wp_logout_url(),
 			'userName' => $current_user->user_login,
 			'navTree' => $menu_items,

--- a/inc/header-localizer-script.php
+++ b/inc/header-localizer-script.php
@@ -144,7 +144,7 @@ if (!function_exists('uds_localize_component_header_script')) {
 		// Prep localized array items for wp_localize_script below.
 		$localized_array = 	array(
 			'loggedIn' => is_user_logged_in(),
-			'loginLink' => site_url() . '/wp-admin' . '?redirect_to=' . urlencode($_SERVER['REQUEST_URI']),
+			'loginLink' => site_url() . '/wp-admin' . '?redirect_to=' . $_SERVER['REQUEST_URI'],
 			'logoutLink' => wp_logout_url(),
 			'userName' => $current_user->user_login,
 			'navTree' => $menu_items,

--- a/inc/hooks.php
+++ b/inc/hooks.php
@@ -49,3 +49,14 @@ if ( ! function_exists( 'uds_wp_add_site_info' ) ) {
 		echo apply_filters( 'uds_wp_site_info_content', $site_info ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 }
+
+function redirect_logged_in_users() {
+	$redirect_url = $_GET["redirect_to"] ?? '';
+
+	if($redirect_url) {
+		wp_redirect( $redirect_url );
+		exit;
+	}
+
+}
+add_action( 'admin_init', 'redirect_logged_in_users' );

--- a/inc/hooks.php
+++ b/inc/hooks.php
@@ -49,14 +49,15 @@ if ( ! function_exists( 'uds_wp_add_site_info' ) ) {
 		echo apply_filters( 'uds_wp_site_info_content', $site_info ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 }
+if ( ! function_exists ( 'redirect_logged_in_users' ) ) {
+    function redirect_logged_in_users() {
+		$redirect_url = $_GET["redirect_to"] ?? '';
 
-function redirect_logged_in_users() {
-	$redirect_url = $_GET["redirect_to"] ?? '';
-
-	if($redirect_url) {
-		wp_redirect( $redirect_url );
-		exit;
+		if($redirect_url) {
+			wp_redirect( $redirect_url );
+			exit;
+		}
 	}
-
 }
+
 add_action( 'admin_init', 'redirect_logged_in_users' );


### PR DESCRIPTION
Subscribers on RTO need to be redirected to the page they logged in on. 
Might be useful for site editors as well.

1. User visits page
2. User clicks login > query param passed to CAS
3. CAS login > user redirected to wp-admin
4. `admin_init` runs to check if query param exists
5. redirect user if necessary 