### PR TITLE
enqueue lodash with admin script

### DIFF
--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -69,7 +69,7 @@ if (!function_exists('uds_wp_admin_scripts')) {
 			$current_screen = get_current_screen();
 			if ( $current_screen->id === 'post' || $current_screen->id === 'page' ) {
 				$js_version = $theme_version . '.' . filemtime(get_template_directory() . '/dist/js/admin-core-bundle.js');
-				wp_enqueue_script('uds-wordpress-admin-core-script', get_template_directory_uri() . '/dist/js/admin-core-bundle.js', array(), $js_version);
+				wp_enqueue_script('uds-wordpress-admin-core-script', get_template_directory_uri() . '/dist/js/admin-core-bundle.js', array('lodash'), $js_version);
 			}
 		}
 


### PR DESCRIPTION
There was no PR or code history for removing `lodash` from v0.56, unfortunately this got overwritten between v0.56 and v0.57 in error.

The theme works on WP Engine without this enqueuing update. Local development on Lando is broken. 