### PR TITLE
Update Primary Branch Name

### DIFF
--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@ Description: Combination of Automattic´s _s theme and Bootstrap 5, customized a
 Version: 1.3.0
 
 GitHub Theme URI: https://github.com/ASU-KE/UDS-WordPress-Theme
-Primary Branch: develop
+Primary Branch: main
 
 License: GNU GPL version 2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
While attempting to update our theme on the Global Futures QA environment, which was telling me that there was a 1.3 release I could use, I realized that there **was not actually a 1.3 release** at all. Git Updater thought there was, however, because it is being told to use `develop` as its primary branch via the comment in `styles.css`.

Not only did we recently get a bunch of emails from the Smart Plugin Manager about failed 1.3 updates across multiple sites, it also caused some confusion on the Global Futures QA when WordPress appeared to have updated the theme when it actually hadn't...and at that point I wasn't sure if we were even on the 1.2 branch, because something similar could have happened before.

Either way, we want our sites to only pay attention to tagged releases on `main`, and this change should accomplish that and prevent unwanted attempts to update the theme before we are ready.

Changes proposed in this pull request:

- update the `Primary Branch` comment in the header to refer to `main` and not `develop`
