### PR TITLE
Fix errors and bugs when no menu items

### DIFF
--- a/inc/class-unity-react-header-navtree-walker.php
+++ b/inc/class-unity-react-header-navtree-walker.php
@@ -89,7 +89,7 @@ if ( ! class_exists('UDS_React_Header_Navtree') ) {
 				}
 
 				// Check for the presence of children. Add array wrapper for future depth.
-				if ( $args->walker->has_children ) {
+				if ( isset($args) && isset($args->walker) && isset($args->walker->has_children) && $args->walker->has_children ) {
 					$entry->items = array();
 				}
 

--- a/inc/header-localizer-script.php
+++ b/inc/header-localizer-script.php
@@ -133,14 +133,14 @@ if (!function_exists('uds_localize_component_header_script')) {
 					array_push($cta_buttons, $item);
 				}
 			}
-
-			// If there are no CTA buttons defined in the menu, the CTA walker explicitly returns a
-			// serlizized empty array. Shouldn't be any need to further check is_serialized().
-
-			$cta_buttons = maybe_unserialize($cta_buttons);
+			if (is_array($cta_buttons) && empty($cta_buttons)) {
+				$cta_buttons = null;
+			}
+			// If there are only CTA buttons, set $menu_items to null
+			if (is_array($menu_items) && count($menu_items) === 1 && !empty($cta_buttons)) {
+				$menu_items = null;
+			}
 		}
-
-
 		// Prep localized array items for wp_localize_script below.
 		$localized_array = 	array(
 			'loggedIn' => is_user_logged_in(),


### PR DESCRIPTION
Header menu would output "0" string when an empty menu with no menu items was set as the main menu. After trial and error it was not an issue with menu items, but the CTA button array.

- `isset` check on walker args, fixes PHP warning user sees `Attempt to read property "has_children" on null`
- set CTA array to null, fixes "0" string output 
- if there are only CTA buttons, set menu items to null. Otherwise home icon is output, and breaks UDS styling. Button should be vertically centered with site title, unless menu items exist, it will snap down to the menu items row.
