### PR TITLE
alerts - remove focus function

### DIFF
--- a/src/js/uds/data-layer.js
+++ b/src/js/uds/data-layer.js
@@ -169,16 +169,8 @@ function initDataLayer() {
 	// Alerts and banners. Events emitted by the .alert element which uses BS5 collapse.
 	document.querySelectorAll('.alert').forEach((element) => {
 
-		// While we are here, let's move the focus appropriately. We'll need the index later.
-		// Recommendation from BS 5: https://getbootstrap.com/docs/5.2/components/alerts/#dismissing
-		var allFocusableElements = document.querySelectorAll(
-			'a[href], button, input, select, textarea, [tabindex]:not([tabindex="-1"])'
-		);
-		var alertButton = element.querySelector('button');
-		var dismissedIndex = Array.from(allFocusableElements).indexOf(alertButton);
-
 		element.addEventListener('close.bs.alert', function () {
-			const name = element.getAttribute('id') || 'unknown-dismiss';
+			const name = element.getAttribute('class') || 'unknown-dismiss';
 			const event = 'dismiss';
 			const action = 'close';
 			const type = 'click';
@@ -197,12 +189,6 @@ function initDataLayer() {
 				region: region.toLowerCase(),
 				text: text.toLowerCase(),
 			});
-
-			if (dismissedIndex !== -1 && dismissedIndex < allFocusableElements.length - 1) {
-				// Focus on the next element
-				var nextElement = allFocusableElements[dismissedIndex + 1];
-				nextElement.focus();
-			}
 
 		});
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
removed function calls that auto focus on the next element
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
with an alert on the page, if an alert is dismissed the page will jump far to the next focus element. Let the user control focus.
## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
local test
## Screenshots (if appropriate):
n/a
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
