### PR TITLE
Custom Block #661: Added Image comparision block

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   - Utilizes standard WordPress features, such as page templates, widgets, and shortcodes, for easy and rapid development of standards-compliant WordPress sites
   - PHP 8 required (v1.6+) / PHP 7.4 compatible (v1.5 and earlier)
 - **Content Components**
-  - 17 custom ACF blocks for UDS-compliant content (cards, banners, alerts, modals, text marquee, etc.)
+  - 19 custom ACF blocks for UDS-compliant content (cards, banners, alerts, modals, text marquee, etc.)
   - 42+ pre-designed block patterns for rapid page building
   - Custom widgets for global banners and footer content
   - Shortcode for sidebar menus

--- a/acf-json/group_69dfdc262626d.json
+++ b/acf-json/group_69dfdc262626d.json
@@ -1,0 +1,196 @@
+{
+    "key": "group_69dfdc262626d",
+    "title": "UDS Block: Image Compare",
+    "fields": [
+        {
+            "key": "field_69dfdc2680618",
+            "label": "Description",
+            "name": "description",
+            "aria-label": "",
+            "type": "text",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "UDS Image Compare",
+            "maxlength": 100,
+            "allow_in_bindings": 0,
+            "placeholder": "",
+            "prepend": "",
+            "append": ""
+        },
+        {
+            "key": "field_69dfdc6180619",
+            "label": "Orientation",
+            "name": "orientation",
+            "aria-label": "",
+            "type": "radio",
+            "instructions": "",
+            "required": 1,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "choices": {
+                "horizontal": "Horizontal",
+                "vertical": "Vertical"
+            },
+            "default_value": "vertical",
+            "return_format": "value",
+            "allow_null": 0,
+            "other_choice": 0,
+            "allow_in_bindings": 0,
+            "layout": "vertical",
+            "save_other_choice": 0
+        },
+        {
+            "key": "field_69dfdce18061a",
+            "label": "Slide Mode",
+            "name": "slide_mode",
+            "aria-label": "",
+            "type": "radio",
+            "instructions": "",
+            "required": 1,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "choices": {
+                "drag": "Drag",
+                "hover": "Hover"
+            },
+            "default_value": "drag",
+            "return_format": "value",
+            "allow_null": 0,
+            "other_choice": 0,
+            "allow_in_bindings": 0,
+            "layout": "vertical",
+            "save_other_choice": 0
+        },
+        {
+            "key": "field_69dfdd2bdc115",
+            "label": "Initial Position",
+            "name": "initial_position",
+            "aria-label": "",
+            "type": "range",
+            "instructions": "",
+            "required": 1,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": 50,
+            "min": 1,
+            "max": 100,
+            "allow_in_bindings": 0,
+            "step": "",
+            "prepend": "",
+            "append": ""
+        },
+        {
+            "key": "field_69dfde051aca6",
+            "label": "Show handle icon",
+            "name": "show_handle_icon",
+            "aria-label": "",
+            "type": "true_false",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "message": "Show icon on slider",
+            "default_value": 1,
+            "allow_in_bindings": 0,
+            "ui": 0,
+            "ui_on_text": "",
+            "ui_off_text": ""
+        },
+        {
+            "key": "field_69dfde331aca7",
+            "label": "Before Image",
+            "name": "before_image",
+            "aria-label": "",
+            "type": "image",
+            "instructions": "",
+            "required": 1,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "return_format": "array",
+            "library": "all",
+            "min_width": "",
+            "min_height": "",
+            "min_size": "",
+            "max_width": "",
+            "max_height": "",
+            "max_size": "",
+            "mime_types": "",
+            "allow_in_bindings": 0,
+            "preview_size": "medium"
+        },
+        {
+            "key": "field_69dfde681aca8",
+            "label": "After Image",
+            "name": "after_image",
+            "aria-label": "",
+            "type": "image",
+            "instructions": "",
+            "required": 1,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "return_format": "array",
+            "library": "all",
+            "min_width": "",
+            "min_height": "",
+            "min_size": "",
+            "max_width": "",
+            "max_height": "",
+            "max_size": "",
+            "mime_types": "",
+            "allow_in_bindings": 0,
+            "preview_size": "medium"
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "block",
+                "operator": "==",
+                "value": "acf\/uds-image-compare"
+            }
+        ]
+    ],
+    "menu_order": 0,
+    "position": "normal",
+    "style": "default",
+    "label_placement": "top",
+    "instruction_placement": "label",
+    "hide_on_screen": "",
+    "active": true,
+    "description": "Fields for block which compares two images with a slider",
+    "show_in_rest": 0,
+    "display_title": "",
+    "allow_ai_access": false,
+    "ai_description": "",
+    "modified": 1776279213
+}

--- a/acf-json/group_69dfdc262626d.json
+++ b/acf-json/group_69dfdc262626d.json
@@ -169,6 +169,52 @@
             "mime_types": "",
             "allow_in_bindings": 0,
             "preview_size": "medium"
+        },
+        {
+            "key": "field_69e00bc5d064b",
+            "label": "Width",
+            "name": "width",
+            "aria-label": "",
+            "type": "number",
+            "instructions": "",
+            "required": 1,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": 800,
+            "min": 200,
+            "max": 1920,
+            "allow_in_bindings": 0,
+            "placeholder": "",
+            "step": "",
+            "prepend": "",
+            "append": ""
+        },
+        {
+            "key": "field_69e00c75d064c",
+            "label": "Height",
+            "name": "height",
+            "aria-label": "",
+            "type": "number",
+            "instructions": "",
+            "required": 1,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": 500,
+            "min": 100,
+            "max": 1000,
+            "allow_in_bindings": 0,
+            "placeholder": "",
+            "step": "",
+            "prepend": "",
+            "append": ""
         }
     ],
     "location": [
@@ -192,5 +238,5 @@
     "display_title": "",
     "allow_ai_access": false,
     "ai_description": "",
-    "modified": 1776279213
+    "modified": 1776290972
 }

--- a/acf-json/group_69dfdc262626d.json
+++ b/acf-json/group_69dfdc262626d.json
@@ -90,7 +90,7 @@
                 "id": ""
             },
             "default_value": 50,
-            "min": 1,
+            "min": 0,
             "max": 100,
             "allow_in_bindings": 0,
             "step": "",
@@ -238,5 +238,5 @@
     "display_title": "",
     "allow_ai_access": false,
     "ai_description": "",
-    "modified": 1776290972
+    "modified": 1776454786
 }

--- a/inc/uds-blocks.php
+++ b/inc/uds-blocks.php
@@ -112,4 +112,5 @@ function register_acf_blocks() {
 	register_block_type( get_template_directory() . '/templates-blocks/show-more' );
 	register_block_type( get_template_directory() . '/templates-blocks/tabbed-panels' );
 	register_block_type( get_template_directory() . '/templates-blocks/text-marquee' );
+	register_block_type( get_template_directory() . '/templates-blocks/image-compare' );
 }

--- a/templates-blocks/image-compare/block.json
+++ b/templates-blocks/image-compare/block.json
@@ -1,0 +1,39 @@
+{
+	"name": "acf/uds-image-compare",
+	"title": "UDS Image Compare",
+	"apiVersion": 3,
+	"version": "1.0.0",
+	"description": "A block that allows you to compare two images with a slider.",
+	"category": "uds",
+	"icon": "format-image",
+	"keywords": ["image", "compare", "slider", "before", "after", "difference"],
+	"acf": {
+		"blockVersion": 3,
+		"mode": "preview",
+		"renderTemplate": "image-compare.php",
+		"validate": false
+	},
+	"supports": {
+		"align": true
+	},
+	"example": {
+		"attributes": {
+			"mode": "preview",
+			"data": {
+				"description": "UDS Image Compare",
+				"orientation": "vertical",
+				"slide_mode": "drag",
+				"initial_position": 50,
+				"show_handle_icon": true,
+				"before_image": {
+					"url": "https://example.com/before.jpg",
+					"alt": "Before image"
+				},
+				"after_image": {
+					"url": "https://example.com/after.jpg",
+					"alt": "After image"
+				}
+			}
+		}
+	}
+}

--- a/templates-blocks/image-compare/block.json
+++ b/templates-blocks/image-compare/block.json
@@ -16,6 +16,9 @@
 	"supports": {
 		"align": true
 	},
+	"viewStyle": "file:./image-compare.css",
+	"viewScript": "file:./image-compare.js",
+	"editorStyle": "file:./image-compare.css",
 	"example": {
 		"attributes": {
 			"mode": "preview",
@@ -32,7 +35,9 @@
 				"after_image": {
 					"url": "https://example.com/after.jpg",
 					"alt": "After image"
-				}
+				},
+				"width": 800,
+				"height": 500
 			}
 		}
 	}

--- a/templates-blocks/image-compare/block.json
+++ b/templates-blocks/image-compare/block.json
@@ -19,6 +19,7 @@
 	"viewStyle": "file:./image-compare.css",
 	"viewScript": "file:./image-compare.js",
 	"editorStyle": "file:./image-compare.css",
+	"editorScript": "file:./image-compare.js",
 	"example": {
 		"attributes": {
 			"mode": "preview",

--- a/templates-blocks/image-compare/image-compare.css
+++ b/templates-blocks/image-compare/image-compare.css
@@ -8,6 +8,15 @@
 	color: var(--bs-body-color);
 }
 
+@media (max-width: 575px) {
+	.uds-image-compare-description {
+		font-size: 0.875rem;
+		font-weight: 400;
+		color: var(--bs-secondary-color, #6c757d);
+		margin-top: 8px;
+	}
+}
+
 .uds-image-compare-wrapper {
 	position: relative;
 	overflow: hidden;
@@ -15,7 +24,8 @@
 	user-select: none;
 	-webkit-user-select: none;
 	touch-action: none;
-	border-radius: 4px;
+	width: 100%;
+	aspect-ratio: 16 / 9; /* default fallback; */
 }
 
 .uds-image-compare-before {
@@ -59,7 +69,6 @@
 	letter-spacing: 0.05em;
 	text-transform: uppercase;
 	padding: 4px 10px;
-	border-radius: 3px;
 	line-height: 1.4;
 	pointer-events: none;
 	z-index: 5;

--- a/templates-blocks/image-compare/image-compare.css
+++ b/templates-blocks/image-compare/image-compare.css
@@ -1,0 +1,152 @@
+/* UDS Image Compare Block Styles */
+.uds-image-compare-description {
+	margin: 12px 0 0;
+	text-align: center;
+	font-size: 1.125rem;
+	font-weight: 600;
+	line-height: var(--bs-body-line-height);
+	color: var(--bs-body-color);
+}
+
+.uds-image-compare-wrapper {
+	position: relative;
+	overflow: hidden;
+	line-height: 0;
+	user-select: none;
+	-webkit-user-select: none;
+	touch-action: none;
+	border-radius: 4px;
+}
+
+.uds-image-compare-before {
+	position: relative; /* sizes the container */
+	display: block;
+	height: 100%;
+}
+
+.uds-image-compare-after {
+	position: absolute;
+	inset: 0;
+	width: 100%;
+	height: 100%;
+	transition: clip-path 0.05s linear;
+}
+
+.uds-image-compare-before img,
+.uds-image-compare-after img {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	display: block;
+	pointer-events: none;
+	-webkit-user-drag: none;
+}
+
+.uds-image-compare--horizontal .uds-image-compare-after {
+	clip-path: inset(0 calc(100% - var(--uds-ic-pos, 50%)) 0 0);
+}
+
+.uds-image-compare--vertical .uds-image-compare-after {
+	clip-path: inset(0 0 calc(100% - var(--uds-ic-pos, 50%)) 0);
+}
+
+.uds-image-compare-label {
+	position: absolute;
+	background: rgba(0, 0, 0, 0.55);
+	color: #fff;
+	font-size: 0.75rem;
+	font-weight: 600;
+	letter-spacing: 0.05em;
+	text-transform: uppercase;
+	padding: 4px 10px;
+	border-radius: 3px;
+	line-height: 1.4;
+	pointer-events: none;
+	z-index: 5;
+}
+
+.uds-image-compare--horizontal .uds-image-compare-label--before {
+	top: 10px;
+	left: 10px;
+}
+
+.uds-image-compare--horizontal .uds-image-compare-label--after {
+	top: 10px;
+	right: 10px;
+}
+
+.uds-image-compare--vertical .uds-image-compare-label--before {
+	top: 10px;
+	left: 50%;
+	transform: translateX(-50%);
+}
+
+.uds-image-compare--vertical .uds-image-compare-label--after {
+	bottom: 10px;
+	left: 50%;
+	transform: translateX(-50%);
+}
+
+.uds-image-compare-handle {
+	position: absolute;
+	z-index: 10;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.uds-image-compare-handle:focus-visible {
+	outline: 3px solid #0088cc;
+	outline-offset: 2px;
+}
+
+.uds-image-compare--horizontal .uds-image-compare-handle {
+	top: 0;
+	left: var(--uds-ic-pos, 50%);
+	width: 0;
+	height: 100%;
+	transform: translateX(-50%);
+	cursor: ew-resize;
+}
+
+.uds-image-compare--horizontal .uds-image-compare-divider {
+	position: absolute;
+	top: 0;
+	width: 2px;
+	height: 100%;
+	background: #fff;
+	box-shadow: 0 0 4px rgba(0, 0, 0, 0.5);
+}
+
+.uds-image-compare--vertical .uds-image-compare-handle {
+	top: var(--uds-ic-pos, 50%);
+	left: 0;
+	width: 100%;
+	height: 0;
+	transform: translateY(-50%);
+	cursor: ns-resize;
+}
+
+.uds-image-compare--vertical .uds-image-compare-divider {
+	position: absolute;
+	left: 0;
+	width: 100%;
+	height: 2px;
+	background: #fff;
+	box-shadow: 0 0 4px rgba(0, 0, 0, 0.5);
+}
+
+.uds-image-compare-icon {
+	position: relative;
+	z-index: 1;
+	background: #fff;
+	border-radius: 50%;
+	width: 40px;
+	height: 40px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	box-shadow: 0 1px 6px rgba(0, 0, 0, 0.4);
+	flex-shrink: 0;
+	color: #333;
+}

--- a/templates-blocks/image-compare/image-compare.css
+++ b/templates-blocks/image-compare/image-compare.css
@@ -23,9 +23,17 @@
 	line-height: 0;
 	user-select: none;
 	-webkit-user-select: none;
-	touch-action: none;
 	width: 100%;
 	aspect-ratio: 16 / 9; /* default fallback; */
+}
+
+/* Allow page scroll in the non-slider axis; block only the slider axis. */
+.uds-image-compare-wrapper.uds-image-compare--horizontal {
+	touch-action: pan-y;
+}
+
+.uds-image-compare-wrapper.uds-image-compare--vertical {
+	touch-action: pan-x;
 }
 
 .uds-image-compare-before {
@@ -102,6 +110,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	touch-action: none;
 }
 
 .uds-image-compare-handle:focus-visible {
@@ -112,7 +121,7 @@
 .uds-image-compare--horizontal .uds-image-compare-handle {
 	top: 0;
 	left: var(--uds-ic-pos, 50%);
-	width: 0;
+	min-width: 44px;
 	height: 100%;
 	transform: translateX(-50%);
 	cursor: ew-resize;
@@ -131,7 +140,7 @@
 	top: var(--uds-ic-pos, 50%);
 	left: 0;
 	width: 100%;
-	height: 0;
+	min-height: 44px;
 	transform: translateY(-50%);
 	cursor: ns-resize;
 }

--- a/templates-blocks/image-compare/image-compare.js
+++ b/templates-blocks/image-compare/image-compare.js
@@ -105,6 +105,34 @@
 			},
 			{ passive: false },
 		);
+
+		// Keyboard support
+		handle.addEventListener("keydown", function (e) {
+			var cur = parseFloat(handle.getAttribute("aria-valuenow"));
+			var next;
+
+			switch (e.key) {
+				case "ArrowRight":
+				case "ArrowUp":
+					next = cur + 2;
+					break;
+				case "ArrowLeft":
+				case "ArrowDown":
+					next = cur - 2;
+					break;
+				case "Home":
+					next = 0;
+					break;
+				case "End":
+					next = 100;
+					break;
+				default:
+					return;
+			}
+
+			e.preventDefault();
+			setPosition(Math.max(0, Math.min(100, next)));
+		});
 	}
 
 	function init() {

--- a/templates-blocks/image-compare/image-compare.js
+++ b/templates-blocks/image-compare/image-compare.js
@@ -1,0 +1,112 @@
+/**
+ * UDS Image Compare Block JavaScript
+ *
+ * @package UDS WordPress Theme
+ */
+
+(function () {
+	"use strict";
+	function initImageCompare(container) {
+		var wrapper = container.querySelector(".uds-image-compare-wrapper");
+		var handle = container.querySelector(".uds-image-compare-handle");
+		var after = container.querySelector(".uds-image-compare-after");
+
+		var isVertical = wrapper.classList.contains("uds-image-compare--vertical");
+		var slideMode = container.dataset.slideMode || "drag";
+		var initialPos = parseFloat(container.dataset.initialPosition);
+
+		if (isNaN(initialPos)) {
+			initialPos = 50;
+		}
+
+		var isDragging = false;
+
+		function getPosition(e) {
+			var rect = wrapper.getBoundingClientRect();
+			var pointer = e.touches ? e.touches[0] : e;
+			var pos;
+
+			if (isVertical) {
+				pos = ((pointer.clientY - rect.top) / rect.height) * 100;
+			} else {
+				pos = ((pointer.clientX - rect.left) / rect.width) * 100;
+			}
+
+			return Math.max(0, Math.min(100, pos));
+		}
+
+		function setPosition(pos) {
+			pos = Math.round(pos * 10) / 10;
+
+			if (isVertical) {
+				handle.style.top = pos + "%";
+				after.style.clipPath = "inset(0 0 " + (100 - pos) + "% 0)";
+			} else {
+				handle.style.left = pos + "%";
+				after.style.clipPath = "inset(0 " + (100 - pos) + "% 0 0)";
+			}
+
+			handle.setAttribute("aria-valuenow", Math.round(pos));
+		}
+
+		setPosition(initialPos);
+
+		//Mouse specific event
+		// Drag mode: update position on mouse/touch move while dragging
+		if (slideMode === "drag") {
+			handle.addEventListener("mousedown", function () {
+				isDragging = true;
+			});
+
+			document.addEventListener("mouseup", function () {
+				isDragging = false;
+			});
+
+			wrapper.addEventListener("mousemove", function (e) {
+				if (isDragging) {
+					setPosition(getPosition(e));
+				}
+			});
+
+			// Hover mode: update position on mouse move without dragging
+		} else if (slideMode === "hover") {
+			wrapper.addEventListener("mousemove", function (e) {
+				setPosition(getPosition(e));
+			});
+		}
+
+		// Touch specific event
+		handle.addEventListener(
+			"touchstart",
+			function () {
+				isDragging = true;
+			},
+			{ passive: true },
+		);
+
+		document.addEventListener("touchend", function () {
+			isDragging = false;
+		});
+
+		wrapper.addEventListener(
+			"touchmove",
+			function (e) {
+				if (isDragging) {
+					e.preventDefault();
+					setPosition(getPosition(e));
+				}
+			},
+			{ passive: false },
+		);
+	}
+
+	function init() {
+		document.querySelectorAll(".uds-image-compare").forEach(initImageCompare);
+	}
+
+	if (document.readyState === "loading") {
+		document.addEventListener("DOMContentLoaded", init);
+	} else {
+		init();
+	}
+})();

--- a/templates-blocks/image-compare/image-compare.js
+++ b/templates-blocks/image-compare/image-compare.js
@@ -11,6 +11,10 @@
 		var handle = container.querySelector(".uds-image-compare-handle");
 		var after = container.querySelector(".uds-image-compare-after");
 
+		if (!wrapper || !handle || !after) {
+			return;
+		}
+
 		var isVertical = wrapper.classList.contains("uds-image-compare--vertical");
 		var slideMode = container.dataset.slideMode || "drag";
 		var initialPos = parseFloat(container.dataset.initialPosition);
@@ -51,15 +55,21 @@
 
 		setPosition(initialPos);
 
-		//Mouse specific event
+		function onMouseUp() {
+			isDragging = false;
+			document.removeEventListener("mouseup", onMouseUp);
+		}
+
+		function onTouchEnd() {
+			isDragging = false;
+			document.removeEventListener("touchend", onTouchEnd);
+		}
+
 		// Drag mode: update position on mouse/touch move while dragging
 		if (slideMode === "drag") {
 			handle.addEventListener("mousedown", function () {
 				isDragging = true;
-			});
-
-			document.addEventListener("mouseup", function () {
-				isDragging = false;
+				document.addEventListener("mouseup", onMouseUp);
 			});
 
 			wrapper.addEventListener("mousemove", function (e) {
@@ -75,18 +85,15 @@
 			});
 		}
 
-		// Touch specific event
+		// Touch events
 		handle.addEventListener(
 			"touchstart",
 			function () {
 				isDragging = true;
+				document.addEventListener("touchend", onTouchEnd);
 			},
 			{ passive: true },
 		);
-
-		document.addEventListener("touchend", function () {
-			isDragging = false;
-		});
 
 		wrapper.addEventListener(
 			"touchmove",

--- a/templates-blocks/image-compare/image-compare.php
+++ b/templates-blocks/image-compare/image-compare.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * UDS Image Compare Block
+ *
+ * @package UDS WordPress Theme
+ */
+
+    $description = get_field( 'description' );
+    $orientation = get_field( 'orientation' );
+    $slide_mode = get_field( 'slide_mode' );
+    $initial_position = get_field( 'initial_position' );
+    $show_handle_icon = get_field( 'show_handle_icon' );
+    $before_image = get_field( 'before_image' );
+    $after_image = get_field( 'after_image' );
+
+    // If additional classes were requested, clean up the input and add them.
+    $additional_classes = '';
+    if ( isset( $block['className'] ) && ! empty( $block['className'] ) ) {
+        $additional_classes = trim( sanitize_text_field( $block['className'] ) );
+    }
+?>
+
+<section class="uds-image-compare <?php echo $additional_classes; ?>">
+    <p><?php echo $description; ?></p>
+</section>

--- a/templates-blocks/image-compare/image-compare.php
+++ b/templates-blocks/image-compare/image-compare.php
@@ -104,6 +104,7 @@
         </div>
         <?php endif; ?>
 
+        <?php if ( $before_url && $after_url ) : ?>
         <div
             class="uds-image-compare-handle"
             role="slider"
@@ -124,6 +125,7 @@
             </div>
             <?php endif; ?>
         </div>
+        <?php endif; ?>
     </div>
    
     <?php if ( $description ) : ?>

--- a/templates-blocks/image-compare/image-compare.php
+++ b/templates-blocks/image-compare/image-compare.php
@@ -5,21 +5,124 @@
  * @package UDS WordPress Theme
  */
 
-    $description = get_field( 'description' );
-    $orientation = get_field( 'orientation' );
-    $slide_mode = get_field( 'slide_mode' );
+    $description      = get_field( 'description' );
+    $orientation      = get_field( 'orientation' );
+    $slide_mode       = get_field( 'slide_mode' ); // 'drag' or 'hover'
     $initial_position = get_field( 'initial_position' );
     $show_handle_icon = get_field( 'show_handle_icon' );
-    $before_image = get_field( 'before_image' );
-    $after_image = get_field( 'after_image' );
+    $before_image     = get_field( 'before_image' );
+    $after_image      = get_field( 'after_image' );
 
     // If additional classes were requested, clean up the input and add them.
     $additional_classes = '';
     if ( isset( $block['className'] ) && ! empty( $block['className'] ) ) {
         $additional_classes = trim( sanitize_text_field( $block['className'] ) );
     }
+
+    // Unique block ID
+    $block_id = isset( $block['id'] ) ? esc_attr( $block['id'] ) : 'uds-ic-' . uniqid();
+
+    $is_vertical = ( 'vertical' === $orientation );
+
+    // Set initial position to 0–100, default to 50.
+    $position = isset( $initial_position ) ? (int) $initial_position : 50;
+    $position = max( 0, min( 100, $position ) );
+
+    // Resolve image URLs and alt text.
+    $before_url = '';
+    $before_alt = '';
+    $after_url  = '';
+    $after_alt  = '';
+
+    if ( is_array( $before_image ) ) {
+        $before_url = isset( $before_image['url'] ) ? esc_url( $before_image['url'] ) : '';
+        $before_alt = isset( $before_image['alt'] ) ? esc_attr( $before_image['alt'] ) : '';
+    } elseif ( ! empty( $before_image ) ) {
+        $before_url = esc_url( $before_image );
+    }
+
+    if ( is_array( $after_image ) ) {
+        $after_url = isset( $after_image['url'] ) ? esc_url( $after_image['url'] ) : '';
+        $after_alt = isset( $after_image['alt'] ) ? esc_attr( $after_image['alt'] ) : '';
+    } elseif ( ! empty( $after_image ) ) {
+        $after_url = esc_url( $after_image );
+    }
+
+    // Return early if no images are provided.
+    if ( empty( $before_url ) && empty( $after_url ) ) {
+        return;
+    }
+
+    $orientation_class = $is_vertical ? 'uds-image-compare--vertical' : 'uds-image-compare--horizontal';
+
+    $custom_width  = get_field( 'width' );
+    $custom_height = get_field( 'height' );
+
+    // --uds-ic-pos sets the initial handle position before JS runs.
+    $inline_style  = '--uds-ic-pos: ' . $position . '%';
+    $inline_style .= $custom_width  ? '; width: '  . intval( $custom_width )  . 'px' : '';
+
+    $wrapper_style = $custom_height ? 'height: ' . intval( $custom_height ) . 'px' : '';
 ?>
 
-<section class="uds-image-compare <?php echo $additional_classes; ?>">
-    <p><?php echo $description; ?></p>
+<section
+    id="<?php echo $block_id; ?>"
+    class="uds-image-compare <?php echo esc_attr( $additional_classes ); ?>"
+    style="<?php echo esc_attr( $inline_style ); ?>"
+    data-slide-mode="<?php echo esc_attr( $slide_mode ? $slide_mode : 'drag' ); ?>"
+    data-initial-position="<?php echo $position; ?>"
+    aria-label="<?php esc_attr_e( 'Image comparison slider', 'uds-wordpress-theme' ); ?>"
+>
+    <div
+        class="uds-image-compare-wrapper <?php echo esc_attr( $orientation_class ); ?>"
+        <?php if ( $wrapper_style ) : ?>style="<?php echo esc_attr( $wrapper_style ); ?>"<?php endif; ?>
+        role="group"
+    >
+        <?php if ( $before_url ) : ?>
+        <div class="uds-image-compare-before" aria-label="<?php esc_attr_e( 'Before', 'uds-wordpress-theme' ); ?>">
+            <img
+                src="<?php echo $before_url; ?>"
+                alt="<?php echo $before_alt; ?>"
+                draggable="false"
+            >
+        </div>
+        <?php endif; ?>
+
+        <?php if ( $after_url ) : ?>
+        <div class="uds-image-compare-after" aria-label="<?php esc_attr_e( 'After', 'uds-wordpress-theme' ); ?>">
+            <img
+                src="<?php echo $after_url; ?>"
+                alt="<?php echo $after_alt; ?>"
+                draggable="false"
+            >
+        </div>
+        <?php endif; ?>
+
+        <div
+            class="uds-image-compare-handle"
+            role="slider"
+            aria-label="<?php esc_attr_e( 'Image comparison handle', 'uds-wordpress-theme' ); ?>"
+            aria-valuemin="0"
+            aria-valuemax="100"
+            aria-valuenow="<?php echo $position; ?>"
+            tabindex="0"
+        >
+            <div class="uds-image-compare-divider"></div>
+            <?php if ( $show_handle_icon ) : ?>
+            <div class="uds-image-compare-icon" aria-hidden="true">
+                <?php if ( $is_vertical ) : ?>
+                <i class="fas fa-up-down" aria-hidden="true"></i>
+                <?php else : ?>
+                <i class="fas fa-left-right" aria-hidden="true"></i>
+                <?php endif; ?>
+            </div>
+            <?php endif; ?>
+        </div>
+    </div>
+   
+    <?php if ( $description ) : ?>
+        <p class="uds-image-compare-description">
+            <?php echo esc_html( $description ); ?>
+        </p>
+    <?php endif; ?>
 </section>

--- a/templates-blocks/image-compare/image-compare.php
+++ b/templates-blocks/image-compare/image-compare.php
@@ -112,6 +112,7 @@ if ( $custom_width && $custom_height ) {
             aria-valuemin="0"
             aria-valuemax="100"
             aria-valuenow="<?php echo esc_attr( $position ); ?>"
+            tabindex="0"
         >
             <div class="uds-image-compare-divider"></div>
             <?php if ( $show_handle_icon ) : ?>

--- a/templates-blocks/image-compare/image-compare.php
+++ b/templates-blocks/image-compare/image-compare.php
@@ -5,74 +5,74 @@
  * @package UDS WordPress Theme
  */
 
-    $description      = get_field( 'description' );
-    $orientation      = get_field( 'orientation' );
-    $slide_mode       = get_field( 'slide_mode' ); // 'drag' or 'hover'
-    $initial_position = get_field( 'initial_position' );
-    $show_handle_icon = get_field( 'show_handle_icon' );
-    $before_image     = get_field( 'before_image' );
-    $after_image      = get_field( 'after_image' );
+$description      = get_field( 'description' );
+$orientation      = get_field( 'orientation' );
+$slide_mode       = get_field( 'slide_mode' ); // 'drag' or 'hover'
+$initial_position = get_field( 'initial_position' );
+$show_handle_icon = get_field( 'show_handle_icon' );
+$before_image     = get_field( 'before_image' );
+$after_image      = get_field( 'after_image' );
 
-    // If additional classes were requested, clean up the input and add them.
-    $additional_classes = '';
-    if ( isset( $block['className'] ) && ! empty( $block['className'] ) ) {
-        $additional_classes = trim( sanitize_text_field( $block['className'] ) );
-    }
+// If additional classes were requested, clean up the input and add them.
+$additional_classes = '';
+if ( isset( $block['className'] ) && ! empty( $block['className'] ) ) {
+    $additional_classes = trim( sanitize_text_field( $block['className'] ) );
+}
 
-    // Unique block ID
-    $block_id = isset( $block['id'] ) ? esc_attr( $block['id'] ) : 'uds-ic-' . uniqid();
+// Unique block ID
+$block_id = 'image-compare-' . $block['id'];
 
-    $is_vertical = ( 'vertical' === $orientation );
+$is_vertical = ( 'vertical' === $orientation );
 
-    // Set initial position to 0–100, default to 50.
-    $position = isset( $initial_position ) ? (int) $initial_position : 50;
-    $position = max( 0, min( 100, $position ) );
+// Set initial position to 0–100, default to 50.
+$position = isset( $initial_position ) ? (int) $initial_position : 50;
+$position = max( 0, min( 100, $position ) );
 
-    // Resolve image URLs and alt text.
-    $before_url = '';
-    $before_alt = '';
-    $after_url  = '';
-    $after_alt  = '';
+// Resolve image URLs and alt text.
+$before_url = '';
+$before_alt = '';
+$after_url  = '';
+$after_alt  = '';
 
-    if ( is_array( $before_image ) ) {
-        $before_url = isset( $before_image['url'] ) ? esc_url( $before_image['url'] ) : '';
-        $before_alt = isset( $before_image['alt'] ) ? esc_attr( $before_image['alt'] ) : '';
-    } elseif ( ! empty( $before_image ) ) {
-        $before_url = esc_url( $before_image );
-    }
+if ( is_array( $before_image ) ) {
+    $before_url = isset( $before_image['url'] ) ? esc_url( $before_image['url'] ) : '';
+    $before_alt = isset( $before_image['alt'] ) ? esc_attr( $before_image['alt'] ) : '';
+} elseif ( ! empty( $before_image ) ) {
+    $before_url = esc_url( $before_image );
+}
 
-    if ( is_array( $after_image ) ) {
-        $after_url = isset( $after_image['url'] ) ? esc_url( $after_image['url'] ) : '';
-        $after_alt = isset( $after_image['alt'] ) ? esc_attr( $after_image['alt'] ) : '';
-    } elseif ( ! empty( $after_image ) ) {
-        $after_url = esc_url( $after_image );
-    }
+if ( is_array( $after_image ) ) {
+    $after_url = isset( $after_image['url'] ) ? esc_url( $after_image['url'] ) : '';
+    $after_alt = isset( $after_image['alt'] ) ? esc_attr( $after_image['alt'] ) : '';
+} elseif ( ! empty( $after_image ) ) {
+    $after_url = esc_url( $after_image );
+}
 
-    // Return early if no images are provided.
-    if ( empty( $before_url ) && empty( $after_url ) ) {
-        return;
-    }
+// Return early if no images are provided.
+if ( empty( $before_url ) && empty( $after_url ) ) {
+    return;
+}
 
-    $orientation_class = $is_vertical ? 'uds-image-compare--vertical' : 'uds-image-compare--horizontal';
+$orientation_class = $is_vertical ? 'uds-image-compare--vertical' : 'uds-image-compare--horizontal';
 
-    $custom_width  = get_field( 'width' );
-    $custom_height = get_field( 'height' );
+$custom_width  = get_field( 'width' );
+$custom_height = get_field( 'height' );
 
-    // --uds-ic-pos sets the initial handle position before JS runs.
-    $inline_style  = '--uds-ic-pos: ' . $position . '%';
-    $inline_style .= $custom_width ? '; max-width: ' . intval( $custom_width ) . 'px; width: 100%' : '';
+// --uds-ic-pos sets the initial handle position before JS runs.
+$inline_style  = '--uds-ic-pos: ' . $position . '%';
+$inline_style .= $custom_width ? '; max-width: ' . intval( $custom_width ) . 'px; width: 100%' : '';
 
-    if ( $custom_width && $custom_height ) {
-        $wrapper_style = 'aspect-ratio: ' . intval( $custom_width ) . ' / ' . intval( $custom_height );
-    } elseif ( $custom_height ) {
-        $wrapper_style = 'max-height: ' . intval( $custom_height ) . 'px';
-    } else {
-        $wrapper_style = '';
-    }
+if ( $custom_width && $custom_height ) {
+    $wrapper_style = 'aspect-ratio: ' . intval( $custom_width ) . ' / ' . intval( $custom_height );
+} elseif ( $custom_height ) {
+    $wrapper_style = 'max-height: ' . intval( $custom_height ) . 'px';
+} else {
+    $wrapper_style = '';
+}
 ?>
 
 <section
-    id="<?php echo $block_id; ?>"
+    id="<?php echo esc_attr( $block_id ); ?>"
     class="uds-image-compare <?php echo esc_attr( $additional_classes ); ?>"
     style="<?php echo esc_attr( $inline_style ); ?>"
     data-slide-mode="<?php echo esc_attr( $slide_mode ? $slide_mode : 'drag' ); ?>"
@@ -87,8 +87,8 @@
         <?php if ( $before_url ) : ?>
         <div class="uds-image-compare-before" aria-label="<?php esc_attr_e( 'Before', 'uds-wordpress-theme' ); ?>">
             <img
-                src="<?php echo $before_url; ?>"
-                alt="<?php echo $before_alt; ?>"
+                src="<?php echo esc_url( $before_url ); ?>"
+                alt="<?php echo esc_attr( $before_alt ); ?>"
                 draggable="false"
             >
         </div>
@@ -97,8 +97,8 @@
         <?php if ( $after_url ) : ?>
         <div class="uds-image-compare-after" aria-label="<?php esc_attr_e( 'After', 'uds-wordpress-theme' ); ?>">
             <img
-                src="<?php echo $after_url; ?>"
-                alt="<?php echo $after_alt; ?>"
+                src="<?php echo esc_url( $after_url ); ?>"
+                alt="<?php echo esc_attr( $after_alt ); ?>"
                 draggable="false"
             >
         </div>
@@ -111,8 +111,7 @@
             aria-label="<?php esc_attr_e( 'Image comparison handle', 'uds-wordpress-theme' ); ?>"
             aria-valuemin="0"
             aria-valuemax="100"
-            aria-valuenow="<?php echo $position; ?>"
-            tabindex="0"
+            aria-valuenow="<?php echo esc_attr( $position ); ?>"
         >
             <div class="uds-image-compare-divider"></div>
             <?php if ( $show_handle_icon ) : ?>

--- a/templates-blocks/image-compare/image-compare.php
+++ b/templates-blocks/image-compare/image-compare.php
@@ -60,9 +60,15 @@
 
     // --uds-ic-pos sets the initial handle position before JS runs.
     $inline_style  = '--uds-ic-pos: ' . $position . '%';
-    $inline_style .= $custom_width  ? '; width: '  . intval( $custom_width )  . 'px' : '';
+    $inline_style .= $custom_width ? '; max-width: ' . intval( $custom_width ) . 'px; width: 100%' : '';
 
-    $wrapper_style = $custom_height ? 'height: ' . intval( $custom_height ) . 'px' : '';
+    if ( $custom_width && $custom_height ) {
+        $wrapper_style = 'aspect-ratio: ' . intval( $custom_width ) . ' / ' . intval( $custom_height );
+    } elseif ( $custom_height ) {
+        $wrapper_style = 'max-height: ' . intval( $custom_height ) . 'px';
+    } else {
+        $wrapper_style = '';
+    }
 ?>
 
 <section


### PR DESCRIPTION
## Description
Added Custom image comparision block with slider

## Motivation and Context

Solves issue #661

- Orientation: Horizontal and vertical
- Slide mode: Drag, Hover
- Custom intial position
- Enable/Disable slider icon
- Custom width and height (Responsive on smaller screens)
- Description fontsize and weight decreases on smaller screens

## How has this been tested?
- Changing the orientation of the slider
- On different screen size
- Changing the slider modes
- Slider works on smaller screens irrespective of slider mode
- Enabling/Disabling the slider

## Screenshots (if appropriate):


https://github.com/user-attachments/assets/50083476-48d0-4adf-9bcc-fcf2b0a2b165

<img width="268" height="663" alt="image" src="https://github.com/user-attachments/assets/4dc09c6e-9bb8-4940-ba08-dadd2f8adc84" />

<img width="265" height="374" alt="image" src="https://github.com/user-attachments/assets/2c3bc6a0-5665-4130-900b-27a2ef830906" />


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] (if appropriate) Run Copilot check for WCAG 2.1 Level AA compliance
